### PR TITLE
Create lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,19 +4,19 @@ on:
   push:
     branches:
       - '*'
-
 jobs:
   build:
-
-    runs-on: macOS-latest
+    name: Lint
+    runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v1
+      - name: Checkout
+        uses: actions/checkout@v4
     
-    - name: Install Cocoapods
-      run: gem install cocoapods
+      - name: Install Cocoapods
+        run: gem install cocoapods
       
-    - name: Deploy to Cocoapods
-      run: |
-        set -eo pipefail
-        pod lib lint
+      - name: Deploy to Cocoapods
+        run: |
+          set -eo pipefail
+          pod lib lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,5 +18,4 @@ jobs:
       
       - name: Deploy to Cocoapods
         run: |
-          set -eo pipefail
-          pod lib lint
+          pod lib lint --verbose

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: lint
+
+on:
+  push:
+    branches:
+      - '*'
+
+jobs:
+  build:
+
+    runs-on: macOS-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    
+    - name: Install Cocoapods
+      run: gem install cocoapods
+      
+    - name: Deploy to Cocoapods
+      run: |
+        set -eo pipefail
+        pod lib lint


### PR DESCRIPTION


---



 **Size S:** This PR changes include 22 lines and should take approximately 15-30 minutes to review



---



 **DeputyDev generated PR summary:** 

The provided pull request (PR) adds a new GitHub Actions workflow file named `lint.yml` to the repository. This workflow is set up to run a linting process on any branch whenever there is a push event. Here's a breakdown of what the workflow does:

1. **Trigger:** The workflow is triggered by a push to any branch (`'*'`).

2. **Job Definition:** It defines a single job named `build` that runs on the latest macOS environment (`macOS-latest`).

3. **Steps:**
   - **Checkout Code:** The `actions/checkout@v1` action is used to check out the repository code into the workflow.
   - **Install Cocoapods:** It installs Cocoapods, a dependency manager for Swift and Objective-C Cocoa projects, using the `gem install cocoapods` command.
   - **Deploy to Cocoapods:** It runs `pod lib lint` to lint the library. The `set -eo pipefail` command is used to ensure that the script stops execution if any command fails, which is a common practice to prevent proceeding with subsequent steps if an error occurs.

This setup is useful for ensuring that any changes pushed to the repository adhere to the specified linting rules for Cocoapods, helping maintain code quality and consistency.